### PR TITLE
Add clipboard and pipeline import support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,8 +127,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -120,6 +147,18 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -197,6 +236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +255,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -239,14 +296,14 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "filedescriptor",
  "futures-core",
  "libc",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -260,6 +317,22 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -278,6 +351,7 @@ name = "epiq"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "clap",
  "crossterm",
@@ -305,6 +379,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +408,22 @@ dependencies = [
  "libc",
  "thiserror",
  "winapi",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -405,6 +516,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +612,12 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -490,6 +642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,12 +670,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -528,7 +693,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -542,12 +707,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.8.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+dependencies = [
+ "bitflags 2.8.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+dependencies = [
+ "bitflags 2.8.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -564,6 +812,16 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "parking_lot"
@@ -585,7 +843,23 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -599,6 +873,25 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -625,6 +918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +934,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radix_trie"
@@ -669,7 +977,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -684,11 +992,24 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -779,6 +1100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +1157,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +1187,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -876,6 +1227,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f943391d896cdfe8eec03a04d7110332d445be7df856db382dd96a730667562c"
+dependencies = [
+ "memchr",
+ "nom",
+ "once_cell",
+ "petgraph",
 ]
 
 [[package]]
@@ -910,6 +1273,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -970,6 +1342,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.0.8",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+dependencies = [
+ "bitflags 2.8.0",
+ "rustix 1.0.8",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.8.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +1445,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1012,7 +1460,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1021,7 +1469,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1030,15 +1493,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1048,9 +1517,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1066,9 +1547,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1078,12 +1571,69 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a083daad7e8a4b8805ad73947ccadabe62afe37ce0e9787a56ff373d34762c7"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 0.38.44",
+ "tempfile",
+ "thiserror",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+dependencies = [
+ "gethostname",
+ "rustix 0.38.44",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.97"
+arboard = { version = "3.6.1", features = ["wayland-data-control"] }
 clap = { version = "4.5.32", features = ["derive"] }
 chrono = "0.4.40"
 # See https://github.com/crossterm-rs/crossterm/issues/935

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ Laboratory for pipeline construction with feedback.
 ## Overview
 
 *empiriqa* (command name is `epiq`) is a tool for interactively manipulating
-UNIX pipelines `|`. You can individually edit, add, delete, and toggle 
+UNIX pipelines `|`. You can individually edit, add, delete, and toggle
 disable/enable for each pipeline stage. It allows you to easily and
 efficiently experiment with data processing and analysis using commands.
 Additionally, you can execute commands with continuous output streams like `tail -f`.
+
+You can start with an empty editor or import an existing pipeline directly from
+the command line (e.g., `epiq 'ls -l | grep txt'`) to pre-populate the editor
+stages and begin experimenting immediately.
 
 *empiriqa* can be considered a generalization of tools like
 [*jnv*](https://github.com/ynqa/jnv) (interactive JSON filter using jq) and
@@ -50,7 +54,10 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ynqa/empiriqa/releases/
 % epiq -h
 Laboratory for pipeline construction with feedback
 
-Usage: epiq [OPTIONS]
+Usage: epiq [OPTIONS] [PIPELINE]
+
+Arguments:
+  [PIPELINE]  Optional pipeline to import (e.g., 'ls -l | grep pattern')
 
 Options:
       --output-queue-size <OUTPUT_QUEUE_SIZE>
@@ -64,6 +71,20 @@ Options:
   -V, --version
           Print version
 ```
+
+## Pipeline Import
+
+You can import an existing pipeline by passing it as an argument when starting
+epiq.
+
+```bash
+epiq 'ls -l | grep txt'
+```
+
+This will create two editor stages that may then be manipulated in the UI:
+
+1. `ls -l`
+2. `grep txt`
 
 ## Keymap
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Options:
 | `Ctrl+B`    | Add new pipeline stage        |
 | `Ctrl+D`    | Delete current pipeline stage |
 | `Ctrl+X`    | Disable/Enable current stage  |
+| `Ctrl+Q`    | Copy pipeline commands        |
+| `Ctrl+O`    | Copy output to clipboard      |
 | `↑`/`↓`     | Move between stages           |
 | `←`/`→`     | Move cursor left/right        |
 | `Ctrl+A`    | Move to beginning of line     |
@@ -128,6 +130,18 @@ testing.
 
 Disabled stages are displayed with a strikethrough, making them visually
 distinguishable.
+
+### Ctrl+Q/Ctrl+O: Clipboard functionality
+
+The current pipeline or reseult may be copied to system for further use.
+
+**Ctrl+Q (Copy Pipeline)**: Copies the current pipeline commands as raw text
+joined with " | " (e.g., "ls -la | grep .txt"). This allows you to easily share
+or save your pipeline configurations.
+
+**Ctrl+O (Copy Output)**: Copies all output currently stored in the queue
+to the clipboard as plain text. Useful for saving results or sharing command
+output.
 
 ### Behavior when resizing
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,16 @@
+use crate::render::NotifyMessage;
+use arboard::Clipboard;
+
+/// Copies the provided content to the system clipboard.
+///
+/// Returns a NotifyMessage indicating success or failure of the operation.
+/// Handles both Clipboard::new() failures and clipboard.set_text() failures gracefully.
+pub fn copy_to_clipboard(content: &str) -> NotifyMessage {
+    match Clipboard::new() {
+        Ok(mut clipboard) => match clipboard.set_text(content) {
+            Ok(_) => NotifyMessage::Success("Copied to clipboard".to_string()),
+            Err(e) => NotifyMessage::Error(format!("Failed to copy to clipboard: {}", e)),
+        },
+        Err(e) => NotifyMessage::Error(format!("Failed to access clipboard: {}", e)),
+    }
+}

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -14,3 +14,29 @@ pub fn copy_to_clipboard(content: &str) -> NotifyMessage {
         Err(e) => NotifyMessage::Error(format!("Failed to access clipboard: {}", e)),
     }
 }
+
+/// Helper function to handle clipboard operations with empty content validation.
+///
+/// Takes content and an empty message, validates the content is not empty,
+/// and either copies to clipboard or returns an error message.
+pub fn copy_with_validation(content: &str, empty_message: &str) -> NotifyMessage {
+    if content.trim().is_empty() {
+        NotifyMessage::Error(empty_message.to_string())
+    } else {
+        copy_to_clipboard(content)
+    }
+}
+
+/// Helper function for pipeline clipboard operations.
+///
+/// Validates pipeline text and copies to clipboard with appropriate error handling.
+pub fn copy_pipeline_to_clipboard(pipeline_text: &str) -> NotifyMessage {
+    copy_with_validation(pipeline_text, "Pipeline is empty")
+}
+
+/// Helper function for output clipboard operations.
+///
+/// Validates output text and copies to clipboard with appropriate error handling.
+pub fn copy_output_to_clipboard(output_text: &str) -> NotifyMessage {
+    copy_with_validation(output_text, "Output queue is empty")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ use crate::{
 #[derive(Parser)]
 #[command(name = "epiq", version)]
 pub struct Args {
+    /// Optional pipeline to import (e.g., 'ls -l | grep pattern')
+    pipeline: Option<String>,
+
     #[arg(
         long,
         default_value = "1000",
@@ -63,6 +66,37 @@ pub struct Args {
                     but may cause screen flickering due to frequent rendering operations."
     )]
     output_render_interval: u64,
+}
+
+/// Parse a pipeline string into individual commands
+///
+/// Takes a pipeline string and splits it by `|` character, trims whitespace from each command,
+/// filters out empty commands, and returns a Vec<String> of valid commands.
+///
+/// # Arguments
+/// * `pipeline` - The pipeline string to parse (e.g., "ls -l | grep pattern")
+///
+/// # Returns
+/// * `Ok(Vec<String>)` - Vector of trimmed, non-empty commands
+/// * `Err(anyhow::Error)` - If no valid commands are found
+///
+/// # Examples
+/// ```
+/// let commands = parse_pipeline("ls -l | grep txt | head -5")?;
+/// assert_eq!(commands, vec!["ls -l", "grep txt", "head -5"]);
+/// ```
+fn parse_pipeline(pipeline: &str) -> anyhow::Result<Vec<String>> {
+    let commands: Vec<String> = pipeline
+        .split('|')
+        .map(|cmd| cmd.trim().to_string())
+        .filter(|cmd| !cmd.is_empty())
+        .collect();
+
+    if commands.is_empty() {
+        anyhow::bail!("No valid commands found in pipeline: '{}'", pipeline);
+    }
+
+    Ok(commands)
 }
 
 #[tokio::main]
@@ -111,29 +145,92 @@ async fn main() -> anyhow::Result<()> {
         .await
     });
 
-    let mut prompt = Prompt::spawn(
-        broadcast_event_tx.subscribe(),
-        notify_tx.clone(),
-        // TODO: Configurable theme
-        (
-            // Head theme
-            EditorTheme {
-                prefix: String::from("❯❯ "),
-                prefix_fg_color: Color::DarkGreen,
-                active_char_bg_color: Color::DarkCyan,
-                word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-            },
-            // Pipe theme
-            EditorTheme {
-                prefix: String::from("❚ "),
-                prefix_fg_color: Color::DarkYellow,
-                active_char_bg_color: Color::DarkCyan,
-                word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-            },
-        ),
-        crossterm::terminal::size()?,
-        shared_renderer.clone(),
-    );
+    let mut prompt = if let Some(ref pipeline_str) = args.pipeline {
+        match parse_pipeline(pipeline_str) {
+            Ok(commands) => {
+                Prompt::spawn_with_pipeline(
+                    broadcast_event_tx.subscribe(),
+                    notify_tx.clone(),
+                    // TODO: Configurable theme
+                    (
+                        // Head theme
+                        EditorTheme {
+                            prefix: String::from("❯❯ "),
+                            prefix_fg_color: Color::DarkGreen,
+                            active_char_bg_color: Color::DarkCyan,
+                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                        },
+                        // Pipe theme
+                        EditorTheme {
+                            prefix: String::from("❚ "),
+                            prefix_fg_color: Color::DarkYellow,
+                            active_char_bg_color: Color::DarkCyan,
+                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                        },
+                    ),
+                    crossterm::terminal::size()?,
+                    shared_renderer.clone(),
+                    commands,
+                )
+            }
+            Err(e) => {
+                // Show error and fall back to empty editor
+                let _ = notify_tx
+                    .send(NotifyMessage::Error(format!(
+                        "Failed to parse pipeline: {}",
+                        e
+                    )))
+                    .await;
+                Prompt::spawn(
+                    broadcast_event_tx.subscribe(),
+                    notify_tx.clone(),
+                    // TODO: Configurable theme
+                    (
+                        // Head theme
+                        EditorTheme {
+                            prefix: String::from("❯❯ "),
+                            prefix_fg_color: Color::DarkGreen,
+                            active_char_bg_color: Color::DarkCyan,
+                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                        },
+                        // Pipe theme
+                        EditorTheme {
+                            prefix: String::from("❚ "),
+                            prefix_fg_color: Color::DarkYellow,
+                            active_char_bg_color: Color::DarkCyan,
+                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                        },
+                    ),
+                    crossterm::terminal::size()?,
+                    shared_renderer.clone(),
+                )
+            }
+        }
+    } else {
+        Prompt::spawn(
+            broadcast_event_tx.subscribe(),
+            notify_tx.clone(),
+            // TODO: Configurable theme
+            (
+                // Head theme
+                EditorTheme {
+                    prefix: String::from("❯❯ "),
+                    prefix_fg_color: Color::DarkGreen,
+                    active_char_bg_color: Color::DarkCyan,
+                    word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                },
+                // Pipe theme
+                EditorTheme {
+                    prefix: String::from("❚ "),
+                    prefix_fg_color: Color::DarkYellow,
+                    active_char_bg_color: Color::DarkCyan,
+                    word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+                },
+            ),
+            crossterm::terminal::size()?,
+            shared_renderer.clone(),
+        )
+    };
 
     'outer: while let Some(events) = event_rx.recv().await {
         for event in events {
@@ -179,11 +276,20 @@ async fn main() -> anyhow::Result<()> {
                                 let _ = notify_tx.send(message).await;
                             }
                             Err(e) => {
-                                let _ = notify_tx.send(NotifyMessage::Error(format!("Failed to get output text: {:?}", e))).await;
+                                let _ = notify_tx
+                                    .send(NotifyMessage::Error(format!(
+                                        "Failed to get output text: {:?}",
+                                        e
+                                    )))
+                                    .await;
                             }
                         }
                     } else {
-                        let _ = notify_tx.send(NotifyMessage::Error("Failed to request output text".to_string())).await;
+                        let _ = notify_tx
+                            .send(NotifyMessage::Error(
+                                "Failed to request output text".to_string(),
+                            ))
+                            .await;
                     }
                 }
                 // There is no way to capture ONLY mouse scroll events,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,9 @@ use crossterm::{
     style::Color,
 };
 use promkit::{PaneFactory, grapheme::StyledGraphemes, text};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
+mod clipboard;
 mod operator;
 mod pipeline;
 mod prompt;
@@ -93,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let (output_tx, output_rx) = mpsc::channel(1);
+    let (oneshot_tx, oneshot_rx) = mpsc::channel::<oneshot::Sender<String>>(1);
     let output_renderer = shared_renderer.clone();
     let output_event_subscriber = broadcast_event_tx.subscribe();
     let output_reset_subscriber = broadcast_reset_tx.subscribe();
@@ -100,6 +102,7 @@ async fn main() -> anyhow::Result<()> {
         output_stream(
             queue::State::new(args.output_queue_size),
             output_rx,
+            oneshot_rx,
             output_event_subscriber,
             output_reset_subscriber,
             output_renderer,
@@ -144,6 +147,55 @@ async fn main() -> anyhow::Result<()> {
                     }),
                     _,
                 )) => break 'outer,
+                // Ctrl+Q: Copy pipeline text to clipboard
+                EventStream::Buffer(Buffer::Other(
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Char('q'),
+                        modifiers: KeyModifiers::CONTROL,
+                        kind: KeyEventKind::Press,
+                        state: KeyEventState::NONE,
+                    }),
+                    _,
+                )) => {
+                    let pipeline_text = prompt.get_all_texts().await.join(" | ");
+                    // Debug: Check if pipeline text is empty
+                    if pipeline_text.trim().is_empty() {
+                        let _ = notify_tx.send(NotifyMessage::Error("Pipeline is empty".to_string())).await;
+                    } else {
+                        let message = clipboard::copy_to_clipboard(&pipeline_text);
+                        let _ = notify_tx.send(message).await;
+                    }
+                }
+                // Ctrl+O: Copy output queue text to clipboard
+                EventStream::Buffer(Buffer::Other(
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Char('o'),
+                        modifiers: KeyModifiers::CONTROL,
+                        kind: KeyEventKind::Press,
+                        state: KeyEventState::NONE,
+                    }),
+                    _,
+                )) => {
+                    let (response_tx, response_rx) = oneshot::channel();
+                    if let Ok(_) = oneshot_tx.send(response_tx).await {
+                        match response_rx.await {
+                            Ok(output_text) => {
+                                // Debug: Check if output text is empty
+                                if output_text.trim().is_empty() {
+                                    let _ = notify_tx.send(NotifyMessage::Error("Output queue is empty".to_string())).await;
+                                } else {
+                                    let message = clipboard::copy_to_clipboard(&output_text);
+                                    let _ = notify_tx.send(message).await;
+                                }
+                            }
+                            Err(e) => {
+                                let _ = notify_tx.send(NotifyMessage::Error(format!("Failed to get output text: {:?}", e))).await;
+                            }
+                        }
+                    } else {
+                        let _ = notify_tx.send(NotifyMessage::Error("Failed to request output text".to_string())).await;
+                    }
+                }
                 // There is no way to capture ONLY mouse scroll events,
                 // so, toggle enabling and disabling of capturing all mouse events with Esc.
                 // https://github.com/crossterm-rs/crossterm/issues/640
@@ -245,6 +297,7 @@ async fn notify_stream(
 async fn output_stream(
     mut queue: queue::State,
     mut stdout_stream: mpsc::Receiver<String>,
+    mut oneshot_stream: mpsc::Receiver<oneshot::Sender<String>>,
     mut event_stream: broadcast::Receiver<EventStream>,
     mut reset: broadcast::Receiver<()>,
     shared_renderer: SharedRenderer,
@@ -281,6 +334,10 @@ async fn output_stream(
                 if shifted {
                     last_modified_time = Local::now();
                 }
+            },
+            Some(response_tx) = oneshot_stream.recv() => {
+                let output_text = queue.get_all_text();
+                let _ = response_tx.send(output_text);
             },
             maybe_line = stdout_stream.recv() => {
                 match maybe_line {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,13 +158,8 @@ async fn main() -> anyhow::Result<()> {
                     _,
                 )) => {
                     let pipeline_text = prompt.get_all_texts().await.join(" | ");
-                    // Debug: Check if pipeline text is empty
-                    if pipeline_text.trim().is_empty() {
-                        let _ = notify_tx.send(NotifyMessage::Error("Pipeline is empty".to_string())).await;
-                    } else {
-                        let message = clipboard::copy_to_clipboard(&pipeline_text);
-                        let _ = notify_tx.send(message).await;
-                    }
+                    let message = clipboard::copy_pipeline_to_clipboard(&pipeline_text);
+                    let _ = notify_tx.send(message).await;
                 }
                 // Ctrl+O: Copy output queue text to clipboard
                 EventStream::Buffer(Buffer::Other(
@@ -180,13 +175,8 @@ async fn main() -> anyhow::Result<()> {
                     if let Ok(_) = oneshot_tx.send(response_tx).await {
                         match response_rx.await {
                             Ok(output_text) => {
-                                // Debug: Check if output text is empty
-                                if output_text.trim().is_empty() {
-                                    let _ = notify_tx.send(NotifyMessage::Error("Output queue is empty".to_string())).await;
-                                } else {
-                                    let message = clipboard::copy_to_clipboard(&output_text);
-                                    let _ = notify_tx.send(message).await;
-                                }
+                                let message = clipboard::copy_output_to_clipboard(&output_text);
+                                let _ = notify_tx.send(message).await;
                             }
                             Err(e) => {
                                 let _ = notify_tx.send(NotifyMessage::Error(format!("Failed to get output text: {:?}", e))).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 use chrono::Local;
 use clap::Parser;
 use crossterm::{
     self,
     event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers},
-    style::Color,
 };
 use promkit::{PaneFactory, grapheme::StyledGraphemes, text};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -14,15 +13,14 @@ mod clipboard;
 mod operator;
 mod pipeline;
 mod prompt;
-use prompt::EditorTheme;
 mod queue;
 mod render;
 use render::NotifyMessage;
 
 use crate::{
     operator::{Buffer, EventOperator, EventStream},
-    pipeline::Pipeline,
-    prompt::Prompt,
+    pipeline::{Pipeline, parse_pipeline},
+    prompt::{Prompt, EditorTheme},
     render::{PaneIndex, SharedRenderer},
 };
 
@@ -68,36 +66,6 @@ pub struct Args {
     output_render_interval: u64,
 }
 
-/// Parse a pipeline string into individual commands
-///
-/// Takes a pipeline string and splits it by `|` character, trims whitespace from each command,
-/// filters out empty commands, and returns a Vec<String> of valid commands.
-///
-/// # Arguments
-/// * `pipeline` - The pipeline string to parse (e.g., "ls -l | grep pattern")
-///
-/// # Returns
-/// * `Ok(Vec<String>)` - Vector of trimmed, non-empty commands
-/// * `Err(anyhow::Error)` - If no valid commands are found
-///
-/// # Examples
-/// ```
-/// let commands = parse_pipeline("ls -l | grep txt | head -5")?;
-/// assert_eq!(commands, vec!["ls -l", "grep txt", "head -5"]);
-/// ```
-fn parse_pipeline(pipeline: &str) -> anyhow::Result<Vec<String>> {
-    let commands: Vec<String> = pipeline
-        .split('|')
-        .map(|cmd| cmd.trim().to_string())
-        .filter(|cmd| !cmd.is_empty())
-        .collect();
-
-    if commands.is_empty() {
-        anyhow::bail!("No valid commands found in pipeline: '{}'", pipeline);
-    }
-
-    Ok(commands)
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -145,91 +113,38 @@ async fn main() -> anyhow::Result<()> {
         .await
     });
 
-    let mut prompt = if let Some(ref pipeline_str) = args.pipeline {
-        match parse_pipeline(pipeline_str) {
-            Ok(commands) => {
-                Prompt::spawn_with_pipeline(
-                    broadcast_event_tx.subscribe(),
-                    notify_tx.clone(),
-                    // TODO: Configurable theme
-                    (
-                        // Head theme
-                        EditorTheme {
-                            prefix: String::from("❯❯ "),
-                            prefix_fg_color: Color::DarkGreen,
-                            active_char_bg_color: Color::DarkCyan,
-                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                        },
-                        // Pipe theme
-                        EditorTheme {
-                            prefix: String::from("❚ "),
-                            prefix_fg_color: Color::DarkYellow,
-                            active_char_bg_color: Color::DarkCyan,
-                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                        },
-                    ),
-                    crossterm::terminal::size()?,
-                    shared_renderer.clone(),
-                    commands,
-                )
-            }
-            Err(e) => {
-                // Show error and fall back to empty editor
-                let _ = notify_tx
-                    .send(NotifyMessage::Error(format!(
-                        "Failed to parse pipeline: {}",
-                        e
-                    )))
-                    .await;
-                Prompt::spawn(
-                    broadcast_event_tx.subscribe(),
-                    notify_tx.clone(),
-                    // TODO: Configurable theme
-                    (
-                        // Head theme
-                        EditorTheme {
-                            prefix: String::from("❯❯ "),
-                            prefix_fg_color: Color::DarkGreen,
-                            active_char_bg_color: Color::DarkCyan,
-                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                        },
-                        // Pipe theme
-                        EditorTheme {
-                            prefix: String::from("❚ "),
-                            prefix_fg_color: Color::DarkYellow,
-                            active_char_bg_color: Color::DarkCyan,
-                            word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                        },
-                    ),
-                    crossterm::terminal::size()?,
-                    shared_renderer.clone(),
-                )
-            }
-        }
-    } else {
-        Prompt::spawn(
+    let mut prompt = match args.pipeline.as_deref().map(parse_pipeline) {
+        Some(Ok(commands)) => Prompt::spawn_with_pipeline(
             broadcast_event_tx.subscribe(),
             notify_tx.clone(),
-            // TODO: Configurable theme
-            (
-                // Head theme
-                EditorTheme {
-                    prefix: String::from("❯❯ "),
-                    prefix_fg_color: Color::DarkGreen,
-                    active_char_bg_color: Color::DarkCyan,
-                    word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                },
-                // Pipe theme
-                EditorTheme {
-                    prefix: String::from("❚ "),
-                    prefix_fg_color: Color::DarkYellow,
-                    active_char_bg_color: Color::DarkCyan,
-                    word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
-                },
-            ),
+            EditorTheme::default_themes(),
             crossterm::terminal::size()?,
             shared_renderer.clone(),
-        )
+            commands,
+        ),
+        Some(Err(e)) => {
+            // Show error and fall back to empty editor
+            let _ = notify_tx
+                .send(NotifyMessage::Error(format!(
+                    "Failed to parse pipeline: {}",
+                    e
+                )))
+                .await;
+            Prompt::spawn(
+                broadcast_event_tx.subscribe(),
+                notify_tx.clone(),
+                EditorTheme::default_themes(),
+                crossterm::terminal::size()?,
+                shared_renderer.clone(),
+            )
+        }
+        None => Prompt::spawn(
+            broadcast_event_tx.subscribe(),
+            notify_tx.clone(),
+            EditorTheme::default_themes(),
+            crossterm::terminal::size()?,
+            shared_renderer.clone(),
+        ),
     };
 
     'outer: while let Some(events) = event_rx.recv().await {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -80,27 +80,7 @@ impl EventOperator {
                             let _ = tx.send(Self::operate(buf.drain(..))).await;
                         },
                         Some(Ok(event)) = event_stream.next() => {
-                            // Check if this is a clipboard shortcut that should be processed immediately
-                            let is_clipboard_shortcut = matches!(event,
-                                crossterm::event::Event::Key(KeyEvent {
-                                    code: KeyCode::Char('q'),
-                                    modifiers: KeyModifiers::CONTROL,
-                                    kind: KeyEventKind::Press,
-                                    state: KeyEventState::NONE,
-                                }) | crossterm::event::Event::Key(KeyEvent {
-                                    code: KeyCode::Char('o'),
-                                    modifiers: KeyModifiers::CONTROL,
-                                    kind: KeyEventKind::Press,
-                                    state: KeyEventState::NONE,
-                                })
-                            );
-
                             buf.push(event);
-
-                            // If it's a clipboard shortcut, process the buffer immediately
-                            if is_clipboard_shortcut {
-                                let _ = tx.send(Self::operate(buf.drain(..))).await;
-                            }
                         },
                     }
                 }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -80,7 +80,27 @@ impl EventOperator {
                             let _ = tx.send(Self::operate(buf.drain(..))).await;
                         },
                         Some(Ok(event)) = event_stream.next() => {
+                            // Check if this is a clipboard shortcut that should be processed immediately
+                            let is_clipboard_shortcut = matches!(event,
+                                crossterm::event::Event::Key(KeyEvent {
+                                    code: KeyCode::Char('q'),
+                                    modifiers: KeyModifiers::CONTROL,
+                                    kind: KeyEventKind::Press,
+                                    state: KeyEventState::NONE,
+                                }) | crossterm::event::Event::Key(KeyEvent {
+                                    code: KeyCode::Char('o'),
+                                    modifiers: KeyModifiers::CONTROL,
+                                    kind: KeyEventKind::Press,
+                                    state: KeyEventState::NONE,
+                                })
+                            );
+
                             buf.push(event);
+
+                            // If it's a clipboard shortcut, process the buffer immediately
+                            if is_clipboard_shortcut {
+                                let _ = tx.send(Self::operate(buf.drain(..))).await;
+                            }
                         },
                     }
                 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -7,6 +7,37 @@ use tokio::{
     task::JoinHandle,
 };
 
+/// Parse a pipeline string into individual commands
+///
+/// Takes a pipeline string and splits it by `|` character, trims whitespace from each command,
+/// filters out empty commands, and returns a Vec<String> of valid commands.
+///
+/// # Arguments
+/// * `pipeline` - The pipeline string to parse (e.g., "ls -l | grep pattern")
+///
+/// # Returns
+/// * `Ok(Vec<String>)` - Vector of trimmed, non-empty commands
+/// * `Err(anyhow::Error)` - If no valid commands are found
+///
+/// # Examples
+/// ```
+/// let commands = parse_pipeline("ls -l | grep txt | head -5")?;
+/// assert_eq!(commands, vec!["ls -l", "grep txt", "head -5"]);
+/// ```
+pub fn parse_pipeline(pipeline: &str) -> anyhow::Result<Vec<String>> {
+    let commands: Vec<String> = pipeline
+        .split('|')
+        .map(|cmd| cmd.trim().to_string())
+        .filter(|cmd| !cmd.is_empty())
+        .collect();
+
+    if commands.is_empty() {
+        anyhow::bail!("No valid commands found in pipeline: '{}'", pipeline);
+    }
+
+    Ok(commands)
+}
+
 pub trait StageKind {}
 
 pub struct Head;

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -11,7 +11,7 @@ use crossterm::{
 };
 use promkit::{PaneFactory, pane::Pane, style::StyleBuilder, text_editor};
 use tokio::{
-    sync::{Mutex, broadcast, mpsc},
+    sync::{Mutex, broadcast, mpsc, oneshot},
     task::JoinHandle,
 };
 
@@ -321,6 +321,7 @@ pub struct Prompt {
     // TODO: reconsider whether mutex is necessary only for get_all_texts
     shared_editors: Arc<Mutex<EditorMap>>,
     pub background: JoinHandle<()>,
+    text_request_tx: mpsc::Sender<oneshot::Sender<Vec<String>>>,
 }
 
 impl Prompt {
@@ -331,6 +332,7 @@ impl Prompt {
         init_terminal_shape: (u16, u16),
         shared_renderer: SharedRenderer,
     ) -> Self {
+        let (text_request_tx, mut text_request_rx) = mpsc::channel::<oneshot::Sender<Vec<String>>>(1);
         let shared_editors = Arc::new(Mutex::new(EditorMap::from(text_editor::State {
             prefix: themes.0.prefix.clone(),
             prefix_style: StyleBuilder::new().fgc(themes.0.prefix_fg_color).build(),
@@ -364,7 +366,8 @@ impl Prompt {
                 }
 
                 loop {
-                    if let Ok(event) = rx.recv().await {
+                    tokio::select! {
+                        Ok(event) = rx.recv() => {
                         match event {
                             EventStream::Debounce(Debounce::Resize(width, height)) => {
                                 terminal_shape = (width, height);
@@ -571,6 +574,17 @@ impl Prompt {
                         };
 
                         let _ = shared_renderer.lock().await.render();
+                        },
+                        Some(response_tx) = text_request_rx.recv() => {
+                            let editors = shared_editors.lock().await;
+                            let texts = editors
+                                .values()
+                                .filter(|editor| !editor.ignore)
+                                .map(|editor| editor.state.texteditor.text_without_cursor().to_string())
+                                .filter(|cmd| !cmd.trim().is_empty())
+                                .collect();
+                            let _ = response_tx.send(texts);
+                        }
                     }
                 }
             })
@@ -579,18 +593,25 @@ impl Prompt {
         Self {
             shared_editors,
             background,
+            text_request_tx,
         }
     }
 
     pub async fn get_all_texts(&mut self) -> Vec<String> {
-        self.shared_editors
-            .lock()
-            .await
-            .values()
-            .filter(|editor| !editor.ignore)
-            .map(|editor| editor.state.texteditor.text_without_cursor().to_string())
-            .filter(|cmd| !cmd.trim().is_empty())
-            .collect()
+        let (response_tx, response_rx) = oneshot::channel();
+        if let Ok(_) = self.text_request_tx.send(response_tx).await {
+            response_rx.await.unwrap_or_default()
+        } else {
+            // Fallback to direct access if channel fails
+            self.shared_editors
+                .lock()
+                .await
+                .values()
+                .filter(|editor| !editor.ignore)
+                .map(|editor| editor.state.texteditor.text_without_cursor().to_string())
+                .filter(|cmd| !cmd.trim().is_empty())
+                .collect()
+        }
     }
 
     fn insert_editor(

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -157,6 +157,28 @@ pub struct EditorTheme {
     pub word_break_chars: HashSet<char>,
 }
 
+impl EditorTheme {
+    /// Create default editor themes for head and pipe editors
+    pub fn default_themes() -> (EditorTheme, EditorTheme) {
+        (
+            // Head theme
+            EditorTheme {
+                prefix: String::from("❯❯ "),
+                prefix_fg_color: Color::DarkGreen,
+                active_char_bg_color: Color::DarkCyan,
+                word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+            },
+            // Pipe theme
+            EditorTheme {
+                prefix: String::from("❚ "),
+                prefix_fg_color: Color::DarkYellow,
+                active_char_bg_color: Color::DarkCyan,
+                word_break_chars: HashSet::from(['.', '|', '(', ')', '[', ']']),
+            },
+        )
+    }
+}
+
 struct Editor {
     state: text_editor::State,
     ignore: bool,

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -326,22 +326,65 @@ pub struct Prompt {
 
 impl Prompt {
     pub fn spawn(
-        mut rx: broadcast::Receiver<EventStream>,
+        rx: broadcast::Receiver<EventStream>,
         notify_tx: mpsc::Sender<NotifyMessage>,
         themes: (EditorTheme, EditorTheme), // (head, pipe)
         init_terminal_shape: (u16, u16),
         shared_renderer: SharedRenderer,
     ) -> Self {
-        let (text_request_tx, mut text_request_rx) = mpsc::channel::<oneshot::Sender<Vec<String>>>(1);
-        let shared_editors = Arc::new(Mutex::new(EditorMap::from(text_editor::State {
-            prefix: themes.0.prefix.clone(),
-            prefix_style: StyleBuilder::new().fgc(themes.0.prefix_fg_color).build(),
-            active_char_style: StyleBuilder::new()
-                .bgc(themes.0.active_char_bg_color)
-                .build(),
-            word_break_chars: themes.0.word_break_chars.clone(),
-            ..Default::default()
-        })));
+        Self::spawn_with_commands(
+            rx,
+            notify_tx,
+            themes,
+            init_terminal_shape,
+            shared_renderer,
+            None,
+        )
+    }
+
+    pub fn spawn_with_pipeline(
+        rx: broadcast::Receiver<EventStream>,
+        notify_tx: mpsc::Sender<NotifyMessage>,
+        themes: (EditorTheme, EditorTheme), // (head, pipe)
+        init_terminal_shape: (u16, u16),
+        shared_renderer: SharedRenderer,
+        commands: Vec<String>,
+    ) -> Self {
+        Self::spawn_with_commands(
+            rx,
+            notify_tx,
+            themes,
+            init_terminal_shape,
+            shared_renderer,
+            Some(commands),
+        )
+    }
+
+    fn spawn_with_commands(
+        mut rx: broadcast::Receiver<EventStream>,
+        notify_tx: mpsc::Sender<NotifyMessage>,
+        themes: (EditorTheme, EditorTheme), // (head, pipe)
+        init_terminal_shape: (u16, u16),
+        shared_renderer: SharedRenderer,
+        commands: Option<Vec<String>>,
+    ) -> Self {
+        let (text_request_tx, mut text_request_rx) =
+            mpsc::channel::<oneshot::Sender<Vec<String>>>(1);
+
+        // Create initial editor map with commands if provided
+        let shared_editors = Arc::new(Mutex::new(if let Some(commands) = commands {
+            Self::create_editors_from_commands(commands, &themes)
+        } else {
+            EditorMap::from(text_editor::State {
+                prefix: themes.0.prefix.clone(),
+                prefix_style: StyleBuilder::new().fgc(themes.0.prefix_fg_color).build(),
+                active_char_style: StyleBuilder::new()
+                    .bgc(themes.0.active_char_bg_color)
+                    .build(),
+                word_break_chars: themes.0.word_break_chars.clone(),
+                ..Default::default()
+            })
+        }));
 
         let background = {
             let mut terminal_shape = init_terminal_shape;
@@ -612,6 +655,55 @@ impl Prompt {
                 .filter(|cmd| !cmd.trim().is_empty())
                 .collect()
         }
+    }
+
+    fn create_editors_from_commands(
+        commands: Vec<String>,
+        themes: &(EditorTheme, EditorTheme),
+    ) -> EditorMap {
+        use promkit::text_editor::TextEditor;
+
+        let mut editors = BTreeMap::new();
+
+        // Create head editor with first command (active)
+        if let Some(first_command) = commands.first() {
+            let head_editor = text_editor::State {
+                texteditor: TextEditor::new(first_command),
+                prefix: themes.0.prefix.clone(),
+                prefix_style: StyleBuilder::new().fgc(themes.0.prefix_fg_color).build(),
+                active_char_style: StyleBuilder::new()
+                    .bgc(themes.0.active_char_bg_color)
+                    .build(),
+                word_break_chars: themes.0.word_break_chars.clone(),
+                ..Default::default()
+            };
+            editors.insert(HEAD_INDEX.clone(), Editor::from(head_editor));
+        }
+
+        // Create pipe editors for remaining commands (inactive)
+        let mut current_index = HEAD_INDEX.clone();
+        for command in commands.iter().skip(1) {
+            let new_index = EditorIndex(current_index.0 + 1, current_index.1);
+            let mut pipe_editor = text_editor::State {
+                texteditor: TextEditor::new(command),
+                prefix: themes.1.prefix.clone(),
+                prefix_style: StyleBuilder::new().fgc(themes.1.prefix_fg_color).build(),
+                active_char_style: StyleBuilder::new().build(),
+                word_break_chars: themes.1.word_break_chars.clone(),
+                ..Default::default()
+            };
+            // Set all styles to dim for inactive editors
+            pipe_editor.prefix_style.attributes.set(Attribute::Dim);
+            pipe_editor.active_char_style.attributes.set(Attribute::Dim);
+            pipe_editor
+                .inactive_char_style
+                .attributes
+                .set(Attribute::Dim);
+            editors.insert(new_index.clone(), Editor::from(pipe_editor));
+            current_index = new_index;
+        }
+
+        EditorMap(editors)
     }
 
     fn insert_editor(

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -53,6 +53,20 @@ impl State {
     pub fn shift(&mut self, up: usize, down: usize) -> bool {
         self.queue.buf.shift(up, down)
     }
+
+    pub fn get_all_text(&self) -> String {
+        self.queue
+            .buf
+            .contents()
+            .iter()
+            .map(|styled_graphemes| {
+                let text = styled_graphemes.to_string();
+                // Handle null characters used for empty lines
+                if text == "\0" { String::new() } else { text }
+            })
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
 }
 
 impl PaneFactory for State {

--- a/src/render.rs
+++ b/src/render.rs
@@ -46,6 +46,7 @@ impl EditorIndex {
 pub enum NotifyMessage {
     None,
     Error(String),
+    Success(String),
 }
 
 impl From<NotifyMessage> for text::State {
@@ -56,6 +57,14 @@ impl From<NotifyMessage> for text::State {
                 text: text::Text::from(message),
                 style: StyleBuilder::new()
                     .fgc(Color::DarkRed)
+                    .attrs(Attributes::from(Attribute::Bold))
+                    .build(),
+                ..Default::default()
+            },
+            NotifyMessage::Success(message) => text::State {
+                text: text::Text::from(message),
+                style: StyleBuilder::new()
+                    .fgc(Color::DarkGreen)
                     .attrs(Attributes::from(Attribute::Bold))
                     .build(),
                 ..Default::default()


### PR DESCRIPTION
Hi!

I recently found empiriqa and it ticks almost all the boxes for an awesome alternative to endless repetition and shell history spamming when creating unix pipelines, thanks a lot!

Having used jnv previously I wanted to mimic the CTRL-Q/O features for copying either the pipeline or output for later use, so here's my attempt at doing so!

It also adds the ability start with an existing pipeline (as requested in #4), which makes it more useful for working with existing pipelines.

I kept the cleanup/refactor commits separate in case to keep the amount of change per commit in check and to allow for choosing an alternate path.

